### PR TITLE
additional error checking, added documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,16 @@ Data returned from the Webservice may be returned as a native Python data struct
 
 ## Quickstart
 
-__To run this Quick Start, you must have an account on the FFIEC Webservice at https://cdr.ffiec.gov/public/PWS/CreateAccount.aspx?PWS=true__
+1. To run this Quick Start, you must have an account on the FFIEC Webservice at https://cdr.ffiec.gov/public/PWS/CreateAccount.aspx?PWS=true
+2. After you create an account, verify your password, and complete the sign-in process, log into the public web interface here: https://cdr.ffiec.gov/Public/PWS/Login.aspx
+3. When you login, go to the "Account Details" tab. On this screen, look for the _Security Token_. This token is the password that you will use for the login credentials for ffiec-data-connect, __not the password__.
+
+Sample code to login and collect reporting periods:
 
 ```
         from ffiec_data_connect import methods, credentials, ffiec_connection
         
-        creds = credentials.WebserviceCredentials(username="user1234", password="password1234")
+        creds = credentials.WebserviceCredentials(username="USER_NAME_GOES_HERE", password="SECURITY_TOKEN_GOES_HERE")
 
         conn = ffiec_connection.FFIECConnection()
 

--- a/Readme.rst
+++ b/Readme.rst
@@ -25,11 +25,15 @@ Installing
 Quick Start
 -----------
 
-**To run this Quick Start, you must have an account on the FFIEC Webservice at https://cdr.ffiec.gov/public/PWS/CreateAccount.aspx?PWS=true .**
+1. To run this Quick Start, you must have an account on the FFIEC Webservice at https://cdr.ffiec.gov/public/PWS/CreateAccount.aspx?PWS=true
+2. After you create an account, verify your password, and complete the sign-in process, log into the public web interface here: https://cdr.ffiec.gov/Public/PWS/Login.aspx
+3. When you login, go to the "Account Details" tab. On this screen, look for the _Security Token_. This token is the password that you will use for the login credentials for ffiec-data-connect, __not the password__.
+
+Sample code to login and collect reporting periods:
 
         from ffiec_data_connect import methods, credentials, ffiec_connection
         
-        creds = credentials.WebserviceCredentials(username="user1234", password="password1234")
+        creds = credentials.WebserviceCredentials(username="USER_NAME_GOES_HERE", password="SECURITY_TOKEN_GOES_HERE")
 
         conn = ffiec_connection.FFIECConnection()
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='ffiec-data-connect',
-    version='0.2.0',
+    python_requires='>3.0.0',
+    version='0.2.1',
     license='MIT',
     description="Wrapper for the FFIEC's Webservice API",
     readme='README.md',

--- a/src/ffiec_data_connect.egg-info/PKG-INFO
+++ b/src/ffiec_data_connect.egg-info/PKG-INFO
@@ -16,7 +16,9 @@ License-File: LICENSE.txt
 
 # FFIEC Data Connector
 
-The FFIEC Webservice Python Connector (`ffiec_data_connect`) was created to facilitate the use of the SOAP-based FFIEC Webservice.
+- The FFIEC Webservice Python Connector library (`ffiec_data_connect`) downloads data from the FFIEC (Federal Financial Institution Examination Council) via the FFIEC's "webservice" interface. 
+
+- The library interfaces with the SOAP-based API published by FFIEC, normalizing dates and data, conducting transformations to permit immediate analysis of acquired data within a Python data science or scripted environment.
 
 
 ### Disclaimer


### PR DESCRIPTION
Merging latest edits into main:
1. Added more descriptive error messages if `call` or `ubpr` series not selected as data series
2. Ignore case for `call` and `ubpr` data series
3. Update documentation to note that the security token should be used for authorization, not the webservice password