### PR TITLE
release: bump version to v2.0.0rc1

### DIFF
--- a/MIGRATION_GUIDE_v2.0.0rc1.md
+++ b/MIGRATION_GUIDE_v2.0.0rc1.md
@@ -1,0 +1,455 @@
+# Release v2.0.0rc1: Comprehensive Type Safety and Quality Assurance
+
+We're excited to announce the first release candidate for FFIEC Data Connect v2.0.0! This release represents a major milestone with comprehensive improvements to code quality, security, and CI/CD infrastructure, while maintaining backward compatibility.
+
+## 🚨 Migration Guide
+
+### Exception Handling Changes (IMPORTANT)
+
+**v2.0.0rc1 introduces new specific exception types** that provide better error context and debugging information. **Legacy compatibility is maintained by default**, but will be disabled in v2.0.0 stable.
+
+#### Current Behavior (Backward Compatible)
+- By default, all errors still raise `ValueError` (legacy mode enabled)
+- A deprecation warning will be shown when legacy mode is used
+
+#### New Exception Types Available
+```python
+# New specific exceptions (when legacy mode disabled)
+from ffiec_data_connect import (
+    FFIECError,           # Base exception
+    ValidationError,      # Input validation failures  
+    CredentialError,      # Authentication/credential issues
+    NoDataError,         # No data returned from API
+    ConnectionError,     # Network/connection issues
+    RateLimitError,      # API rate limit exceeded
+    XMLParsingError,     # XML/XBRL parsing failures
+    SessionError         # Session management issues
+)
+```
+
+#### Migration Path
+1. **Immediate (Optional)**: Disable legacy mode to use new exceptions:
+   ```python
+   import ffiec_data_connect
+   ffiec_data_connect.disable_legacy_mode()
+   ```
+
+2. **Before v2.0.0 Stable**: Update your exception handling:
+   ```python
+   # Old (will stop working in v2.0.0)
+   try:
+       data = collect_data(rssd_id="12345", reporting_period="2023-12-31")
+   except ValueError as e:
+       print(f"Error: {e}")
+   
+   # New (recommended)
+   try:
+       data = collect_data(rssd_id="12345", reporting_period="2023-12-31")
+   except ValidationError as e:
+       print(f"Validation error: {e.message}, Details: {e.details}")
+   except NoDataError as e:
+       print(f"No data found: {e.message}")
+   except FFIECError as e:  # Catches all FFIEC-specific errors
+       print(f"FFIEC error: {e.message}")
+   ```
+
+3. **Environment Variable Control**:
+   ```bash
+   # Enable legacy mode (default in rc1)
+   export FFIEC_USE_LEGACY_ERRORS=true
+   
+   # Disable legacy mode (recommended for new code)
+   export FFIEC_USE_LEGACY_ERRORS=false
+   ```
+
+### New Features Available
+
+#### Async Support (New in v1.0)
+```python
+from ffiec_data_connect import AsyncCompatibleClient
+
+# New async client with automatic rate limiting
+async with AsyncCompatibleClient(credentials) as client:
+    # Collect data from multiple banks concurrently
+    tasks = [
+        client.collect_data_async(rssd_id="12345", reporting_period="2023-12-31"),
+        client.collect_data_async(rssd_id="67890", reporting_period="2023-12-31")
+    ]
+    results = await asyncio.gather(*tasks)
+```
+
+#### Enhanced Data Processing
+```python
+# Direct Polars conversion (preserves numerical precision)
+data = collect_data(rssd_id="12345", reporting_period="2023-12-31", output="polars")
+
+# Multiple output formats supported
+data_list = collect_data(..., output="list")        # List of dicts
+data_pandas = collect_data(..., output="pandas")    # pandas DataFrame  
+data_polars = collect_data(..., output="polars")    # Polars DataFrame
+```
+
+## 🚀 What's New
+
+### Quality Assurance & CI/CD
+- **Comprehensive CI/CD Pipeline**: Added extensive GitHub Actions workflows with 258+ tests across multiple Python versions
+- **Security Scanning**: Integrated bandit and safety tools for security vulnerability detection
+- **Code Quality Checks**: Full integration of flake8 (linting), black (formatting), and mypy (type checking)
+- **Coverage Analysis**: Automated code coverage reporting with detailed metrics
+- **Thread Safety Testing**: Dedicated tests for race conditions and concurrent access patterns
+- **Memory Leak Detection**: Comprehensive memory usage monitoring and leak prevention
+- **Performance Benchmarks**: Async vs sync performance comparison and optimization tracking
+
+### Security Improvements
+- **Fixed MD5 Usage**: Resolved high-severity security warning for cache key generation
+- **XML Security**: Added defusedxml dependency to prevent XXE attacks
+- **Credential Masking**: Enhanced security for credential representation in logs and debugging
+- **Input Validation**: Comprehensive validation for all method parameters
+- **Immutable Credentials**: Credentials cannot be modified after initialization
+
+### GitHub Actions Modernization
+- **Updated Action Versions**: All GitHub Actions updated to latest stable versions
+  - actions/setup-python: v4 → v5
+  - actions/cache: v3 → v4
+  - actions/upload-artifact: v3 → v4
+  - actions/download-artifact: v3 → v4
+  - actions/github-script: v6 → v7
+- **Python Version Support**: Correctly supporting Python 3.10, 3.11, 3.12 (removed 3.9)
+
+### Dependencies & Configuration  
+- **Enhanced Dependencies**: Added defusedxml for XML security
+- **Polars Integration**: Full support for optional polars dependencies in testing
+- **Configuration Fixes**: Updated pyproject.toml with correct contact information
+
+## 🔧 Technical Improvements
+
+### Test Coverage
+- **258+ Individual Tests** across 7 comprehensive test suites
+- **Multi-Python Testing**: Verified compatibility across Python 3.10, 3.11, 3.12
+- **Specialized Testing**: Security, race conditions, memory leaks, async integration
+- **Coverage Tracking**: Building towards 85% coverage target (currently at 53.2%)
+
+### Key Testing Areas
+- **Security**: Credential masking, XXE prevention, input validation
+- **Race Conditions**: Thread-safe session management, concurrent access patterns
+- **Memory Management**: Leak detection, resource cleanup, garbage collection monitoring
+- **Async Integration**: Real-world async patterns, rate limiting, comprehensive error handling
+- **Performance**: Memory efficiency, connection reuse, parallel processing optimization
+
+### Memory Management
+- **Memory Leak Prevention**: Proper cleanup with `__del__` and `close()` methods
+- **SOAP Client Caching**: Prevent expensive client recreation
+- **Session Management**: Automatic session cleanup and resource management
+- **XML Processing Optimization**: Reduced memory copies during XML processing
+- **Context Manager Support**: Automatic resource cleanup with `with` statements
+
+## ⚠️ Deprecation Notices & Technical Migration Guide
+
+### 1. Legacy Exception Mode (Will be disabled by default in v2.0.0 stable)
+
+#### Technical Details
+- **Current Default**: `FFIEC_USE_LEGACY_ERRORS=true` (backward compatible)
+- **v2.0.0 Default**: `FFIEC_USE_LEGACY_ERRORS=false` (new specific exceptions)
+- **Timeline**: Legacy mode will remain available but not default
+
+#### Migration Steps
+
+**Step 1: Identify Current Exception Handling**
+```python
+# Find all existing exception handling in your codebase
+# Look for patterns like:
+try:
+    data = collect_data(...)
+except ValueError as e:
+    # This will need updating
+    handle_error(e)
+```
+
+**Step 2: Test with New Exceptions (Recommended)**
+```python
+# In your test environment, disable legacy mode early
+import os
+os.environ['FFIEC_USE_LEGACY_ERRORS'] = 'false'
+# OR
+import ffiec_data_connect
+ffiec_data_connect.disable_legacy_mode()
+```
+
+**Step 3: Update Exception Handling Patterns**
+```python
+# OLD PATTERN (will break in v2.0.0)
+try:
+    periods = collect_reporting_periods(credentials)
+    data = collect_data(rssd_id, reporting_period, credentials)
+except ValueError as e:
+    if "credential" in str(e).lower():
+        handle_auth_error(e)
+    elif "validation" in str(e).lower():
+        handle_validation_error(e)
+    else:
+        handle_generic_error(e)
+
+# NEW PATTERN (recommended)
+try:
+    periods = collect_reporting_periods(credentials)
+    data = collect_data(rssd_id, reporting_period, credentials)
+except CredentialError as e:
+    # Specific handling for auth issues
+    logger.error(f"Authentication failed: {e.message}")
+    if e.details.get('credential_source'):
+        logger.info(f"Check {e.details['credential_source']} credentials")
+except ValidationError as e:
+    # Specific handling for input validation
+    logger.error(f"Invalid {e.details['field']}: got '{e.details['provided_value']}', expected {e.details['expected']}")
+except NoDataError as e:
+    # Handle no data scenarios gracefully
+    logger.warning(f"No data for RSSD {e.details.get('rssd_id')} in period {e.details.get('reporting_period')}")
+    return None
+except ConnectionError as e:
+    # Network/service issues
+    logger.error(f"Connection failed to {e.details.get('url')}: {e.message}")
+    if e.details.get('status_code'):
+        logger.info(f"HTTP status: {e.details['status_code']}")
+except FFIECError as e:
+    # Catch-all for any other FFIEC-specific errors
+    logger.error(f"FFIEC error: {e.message}, details: {e.details}")
+```
+
+**Step 4: Exception-Specific Migration Patterns**
+
+```python
+# Credential validation errors
+try:
+    creds = WebserviceCredentials(username="test", password="test")
+    creds.validate()
+except CredentialError as e:
+    # New: Rich context about what failed
+    print(f"Credential issue: {e.message}")
+    print(f"Source: {e.details.get('credential_source', 'unknown')}")
+    # Handle based on specific credential problem
+
+# Input validation errors  
+try:
+    data = collect_data(rssd_id="invalid", reporting_period="bad-date")
+except ValidationError as e:
+    # New: Know exactly which field failed and why
+    field = e.details['field']
+    provided = e.details['provided_value'] 
+    expected = e.details['expected']
+    print(f"Field '{field}' validation failed")
+    print(f"You provided: {provided}")
+    print(f"Expected format: {expected}")
+    # Show user exactly what to fix
+
+# No data scenarios
+try:
+    data = collect_data(rssd_id="99999", reporting_period="2023-12-31")
+except NoDataError as e:
+    # New: Context about what was searched for
+    rssd_id = e.details.get('rssd_id')
+    period = e.details.get('reporting_period')
+    if rssd_id and period:
+        print(f"No data found for bank {rssd_id} in period {period}")
+        # Maybe suggest alternative periods or banks
+    # Handle gracefully instead of crashing
+```
+
+**Step 5: Configuration Management**
+
+```python
+# Production deployment configuration
+class FFIECConfig:
+    def __init__(self):
+        # Explicit configuration for production
+        if os.getenv('ENVIRONMENT') == 'production':
+            # Use new exceptions in production for better monitoring
+            ffiec_data_connect.disable_legacy_mode()
+            self.use_detailed_errors = True
+        else:
+            # Keep legacy mode in development during transition
+            ffiec_data_connect.enable_legacy_mode()
+            self.use_detailed_errors = False
+    
+    def setup_error_handling(self):
+        if self.use_detailed_errors:
+            # Configure structured logging for new exceptions
+            import logging
+            logging.getLogger('ffiec_data_connect').setLevel(logging.INFO)
+```
+
+### 2. Python 3.9 Support Removal
+
+#### Technical Impact
+- **Removed**: Python 3.9 testing and support
+- **Minimum**: Python 3.10+ required
+- **Reason**: Leverages Python 3.10+ features (match statements, type union syntax)
+
+#### Migration Steps
+
+**Step 1: Check Current Python Version**
+```bash
+python --version
+# If output shows Python 3.9.x, you need to upgrade
+```
+
+**Step 2: Update Environment**
+```bash
+# Using pyenv
+pyenv install 3.10.12
+pyenv local 3.10.12
+
+# Using conda
+conda create -n ffiec-env python=3.10
+conda activate ffiec-env
+
+# Using Docker
+FROM python:3.10-slim
+```
+
+**Step 3: Update CI/CD Pipelines**
+```yaml
+# GitHub Actions
+strategy:
+  matrix:
+    python-version: ['3.10', '3.11', '3.12']  # Remove '3.9'
+
+# Docker
+FROM python:3.10-slim  # Update from python:3.9
+
+# tox.ini
+[tox]
+envlist = py310,py311,py312  # Remove py39
+```
+
+**Step 4: Dependency Compatibility Check**
+```bash
+# Test your existing requirements with Python 3.10+
+pip install -r requirements.txt
+python -c "import ffiec_data_connect; print('OK')"
+```
+
+### 3. Code Patterns That Need Attention
+
+#### Type Annotations (Enhanced in v1.0)
+```python
+# OLD: Generic typing
+from typing import Union, Optional
+def collect_data(rssd_id: Union[str, int]) -> Optional[dict]:
+    pass
+
+# NEW: Enhanced with specific return types
+from typing import Union, Optional, Dict, List
+import pandas as pd
+try:
+    import polars as pl
+    PolarsDataFrame = pl.DataFrame
+except ImportError:
+    PolarsDataFrame = None
+
+def collect_data(
+    rssd_id: Union[str, int], 
+    output: str = "pandas"
+) -> Union[List[Dict], pd.DataFrame, PolarsDataFrame]:
+    pass
+```
+
+#### Async Patterns (New in v1.0)
+```python
+# NEW: Async support available
+import asyncio
+from ffiec_data_connect import AsyncCompatibleClient
+
+async def collect_multiple_banks():
+    async with AsyncCompatibleClient(credentials) as client:
+        # Concurrent data collection
+        tasks = []
+        for rssd_id in bank_list:
+            task = client.collect_data_async(rssd_id, reporting_period)
+            tasks.append(task)
+        
+        # Wait for all to complete
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        
+        # Handle mixed success/failure results
+        for i, result in enumerate(results):
+            if isinstance(result, Exception):
+                logger.error(f"Bank {bank_list[i]} failed: {result}")
+            else:
+                process_bank_data(result)
+```
+
+### 4. Testing Migration
+
+#### Update Test Patterns
+```python
+# OLD: Test for generic ValueError
+def test_invalid_rssd():
+    with pytest.raises(ValueError):
+        collect_data(rssd_id="invalid")
+
+# NEW: Test for specific exceptions
+def test_invalid_rssd():
+    with pytest.raises(ValidationError) as exc_info:
+        collect_data(rssd_id="invalid")
+    
+    # Test exception details
+    assert exc_info.value.details['field'] == 'rssd_id'
+    assert 'invalid' in exc_info.value.details['provided_value']
+
+# NEW: Test legacy compatibility mode
+def test_legacy_mode():
+    ffiec_data_connect.enable_legacy_mode()
+    with pytest.raises(ValueError):  # Should still work
+        collect_data(rssd_id="invalid")
+    ffiec_data_connect.disable_legacy_mode()
+```
+
+### 5. Monitoring and Logging Updates
+
+```python
+# Enhanced error monitoring with new exceptions
+import structlog
+logger = structlog.get_logger()
+
+try:
+    data = collect_data(rssd_id, period)
+except ValidationError as e:
+    logger.error("validation_failed", 
+                field=e.details['field'],
+                provided_value=e.details['provided_value'],
+                expected=e.details['expected'])
+except CredentialError as e:
+    logger.error("authentication_failed",
+                source=e.details.get('credential_source'),
+                message=e.message)
+except NoDataError as e:
+    logger.warning("no_data_returned",
+                  rssd_id=e.details.get('rssd_id'),
+                  reporting_period=e.details.get('reporting_period'))
+```
+
+## 📋 Release Checklist
+
+- ✅ All GitHub Actions use latest stable versions
+- ✅ Security vulnerabilities resolved (bandit scan clean)
+- ✅ Code quality checks integrated (flake8, black, mypy)
+- ✅ Comprehensive test suite passing (258+ tests)
+- ✅ Multi-Python version compatibility verified
+- ✅ Documentation builds successfully
+- ✅ Dependencies properly configured
+- ✅ Backward compatibility maintained with legacy mode
+- ✅ Ready for PyPI publication
+
+## 🔗 Links
+
+- **GitHub Repository**: [civic-forge/ffiec-data-connect](https://github.com/civic-forge/ffiec-data-connect)  
+- **Documentation**: [ffiec-data-connect.readthedocs.io](https://ffiec-data-connect.readthedocs.io/)
+- **PyPI Package**: [pypi.org/project/ffiec-data-connect](https://pypi.org/project/ffiec-data-connect/)
+
+## 🙏 Acknowledgments
+
+This release represents extensive work on infrastructure, security, and quality assurance to prepare the FFIEC Data Connect library for production use with enterprise-grade reliability and performance.
+
+---
+
+**Note**: This is a release candidate. The API is stable, but please test thoroughly and report any issues before the stable v1.0.0 release. All existing code will continue to work unchanged, but migrating to new exception handling is recommended.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ffiec-data-connect"
-version = "1.0.0rc1"
+version = "2.0.0rc1"
 authors = [
     {name = "Civic Forge Solutions LLC", email = "michael@civicforge.solutions"},
 ]

--- a/src/ffiec_data_connect/__init__.py
+++ b/src/ffiec_data_connect/__init__.py
@@ -6,7 +6,7 @@ with support for both synchronous and asynchronous operations.
 """
 
 # Version
-__version__ = "1.0.0rc1"
+__version__ = "2.0.0rc1"
 
 # New async-compatible client
 from ffiec_data_connect.async_compatible import AsyncCompatibleClient, RateLimiter

--- a/src/ffiec_data_connect/config.py
+++ b/src/ffiec_data_connect/config.py
@@ -31,7 +31,7 @@ class Config:
             import warnings
 
             warnings.warn(
-                "Legacy error mode is deprecated and will be disabled by default in version 1.0.0. "
+                "Legacy error mode is deprecated and will be disabled by default in version 2.0.0. "
                 "The new exception types provide better error context and debugging information. "
                 "To migrate: catch specific exceptions (CredentialError, ValidationError, etc.) instead of ValueError. "
                 "To disable this warning and opt into new behavior: set FFIEC_USE_LEGACY_ERRORS=false or call disable_legacy_mode().",

--- a/tests/unit/test_legacy_compatibility.py
+++ b/tests/unit/test_legacy_compatibility.py
@@ -248,7 +248,7 @@ class TestLegacyErrorMode:
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
             assert "Legacy error mode is deprecated" in str(w[0].message)
-            assert "version 1.0.0" in str(w[0].message)
+            assert "version 2.0.0" in str(w[0].message)
 
         # Warning should only be shown once
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
- Update version in pyproject.toml and __init__.py to 2.0.0rc1
- Update deprecation warning to reference v2.0.0
- Create comprehensive migration guide for v2.0.0rc1
- Reflects major version bump due to significant new features and API enhancements

Should have been a 2.x, not a 1.x release. Apologies for the confusion!)