### PR TITLE
Release 3.0.0 — first stable on the 3.x line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-04-22
+
+**First stable release of the 3.x line.** Ships with the same code as
+`3.0.0rc6`; there are no behavior differences. This entry exists so
+anyone landing on the latest version can see the full scope of 3.0.0
+in one place.
+
+Major themes vs. `2.0.5`:
+
+- **SOAP support removed.** The FFIEC SOAP webservice was shut down on
+  2026-02-28. `WebserviceCredentials`, `FFIECConnection`, `SOAPAdapter`,
+  and their friends are gone; attempting to instantiate them raises
+  `SOAPDeprecationError`. REST with `OAuth2Credentials` is the only
+  path.
+- **Simplified calling convention.** `collect_*(creds, ...)` — no
+  `session` argument. The v2-style `session=None, creds=creds` keyword
+  form still works (with `DeprecationWarning`) for incremental
+  migration.
+- **Python 3.11+ required** (was 3.10). Matches pandas 3.0's floor.
+- **pandas 3.0 baseline.** `pandas>=3.0.0,<4.0.0` (was `>=1.3.0,<3.0.0`).
+- **`output_type="xbrl"` / `"pdf"`** added on `collect_data` and
+  `collect_ubpr_facsimile_data` (where XBRL is the only FFIEC-supported
+  format) for raw-bytes passthrough.
+- **`date_output_format="python_format"` returns tz-aware datetimes**
+  labeled `America/New_York` — FFIEC publishes wall-clock DC time with
+  no tz marker, so the library attaches one for you. DST honored via
+  `zoneinfo`.
+- **Silent no-ops promoted to errors** — several v2 parameter
+  combinations that did nothing (`output_type="bytes"` on `collect_data`,
+  `output_type="polars"` without the extra installed, `date_output_format`
+  stubs on three list-returning methods) now raise `ValidationError`.
+- **100% REST parity with former SOAP output.** Dual field names
+  (`rssd` + `id_rssd`), leading-zero ZIPs preserved, consistent NumPy
+  dtypes end-to-end.
+- **Async support.** `AsyncCompatibleClient` + `RateLimiter` for
+  parallel collection at up to 5× throughput.
+- **`FFIECError` exception hierarchy** with structured context,
+  opt-in-able via `disable_legacy_mode()` or `FFIEC_USE_LEGACY_ERRORS=false`.
+  Legacy `ValueError` mode is the default for v2 back-compat and will
+  flip in a future release.
+
+The full per-RC history — `rc1` through `rc6` — remains below for anyone
+following along with development.
+
 ## [3.0.0rc6] - 2026-04-22
 
 Vestigial-argument audit: warnings on silently-ignored parameter

--- a/llms.txt
+++ b/llms.txt
@@ -71,10 +71,15 @@ Also applies to: `collect_ubpr_reporting_periods`, `collect_ubpr_facsimile_data`
 
 ALTERNATIVE (deprecated, emits DeprecationWarning):
 ```python
+# Positional-None form
 collect_reporting_periods(None, creds, ...)
 collect_data(None, creds, ...)
+
+# Keyword form (restored in 3.0.0rc4 after briefly breaking in rc1-rc3)
+collect_reporting_periods(session=None, creds=creds, ...)
+collect_data(session=None, creds=creds, ...)
 ```
-Passing `None` as the first argument still works but triggers a `DeprecationWarning`.
+Both forms still work but trigger a `DeprecationWarning`. The `session=None, creds=creds` kwarg form matches what the v2.x docs showed, so AI agents refactoring older code will commonly encounter it.
 
 ### Rule 4: Update imports
 
@@ -141,6 +146,46 @@ Token expiry is now automatically extracted from the JWT `exp` claim.
 `creds.is_expired` returns True if token expires within 24 hours.
 `creds.token_expires` returns the expiry datetime.
 
+Passing `token_expires=...` as a constructor argument still works but emits a `DeprecationWarning` (since 3.0.0rc4) — the JWT's own `exp` claim is authoritative and any value passed here is discarded. Drop the argument.
+
+### Rule 8: Replace output_type="bytes" with "xbrl" or "pdf"
+
+As of 3.0.0rc4, `output_type="bytes"` is deprecated and now behaves differently depending on the method:
+
+FIND:
+```python
+# v2 pattern — was inconsistent across methods, "worked" silently on some
+data = collect_data(conn, creds, ..., output_type="bytes")
+```
+
+REPLACE WITH:
+```python
+# For XBRL XML bytes (works on collect_data and collect_ubpr_facsimile_data):
+data = collect_data(creds, ..., output_type="xbrl")
+# For PDF bytes (works on collect_data only — UBPR endpoint is XBRL-only):
+data = collect_data(creds, ..., output_type="pdf")
+```
+
+On `collect_ubpr_facsimile_data`, `output_type="bytes"` is transparently translated to `"xbrl"` (with `DeprecationWarning`). On every other method, `output_type="bytes"` now raises `ValidationError` — those methods have no raw-bytes representation; the v2 "bytes" on them was a silent no-op returning `None` (from `collect_data`) or a list (from the other five methods).
+
+### Rule 9: Polars output requires the [polars] extra (or switch to pandas)
+
+As of 3.0.0rc6, `output_type="polars"` without the optional extra raises `ValidationError` instead of silently returning a Python list. If a v2 script used polars output "successfully" but didn't install the extra, it was getting a list — which is a bug, not a feature.
+
+FIND:
+```python
+data = collect_reporting_periods(creds, output_type="polars")
+```
+
+REPLACE WITH, EITHER:
+```bash
+pip install 'ffiec-data-connect[polars]'   # Then leave output_type="polars" as-is
+```
+OR:
+```python
+data = collect_reporting_periods(creds, output_type="pandas")   # or "list"
+```
+
 ## Method Reference
 
 All 7 public methods. Preferred calling convention is `collect_*(creds, ...)` (no session parameter):
@@ -159,9 +204,10 @@ All 7 public methods. Preferred calling convention is `collect_*(creds, ...)` (n
 
 | Variable | Status | Notes |
 |----------|--------|-------|
-| `FFIEC_USERNAME` | No longer used | Was for WebserviceCredentials env var mode |
-| `FFIEC_PASSWORD` | No longer used | Was for WebserviceCredentials env var mode |
-| `FFIEC_USE_LEGACY_ERRORS` | Still active | Controls error mode (ValueError vs typed exceptions) |
+| `FFIEC_USERNAME` | No longer auto-read | Was for WebserviceCredentials env var mode. OAuth2Credentials requires the username to be passed explicitly; notebooks often use this env var as a convention (`os.environ["FFIEC_USERNAME"]`) but the library itself no longer reads it. |
+| `FFIEC_PASSWORD` | No longer used | Was for WebserviceCredentials env var mode. REST uses JWT; there is no password. |
+| `FFIEC_BEARER_TOKEN` | Consulted on empty-token error | If `OAuth2Credentials(..., bearer_token="")` is constructed with an empty string, the error message tells the user to set this env var. No other auto-read. |
+| `FFIEC_USE_LEGACY_ERRORS` | Still active (default: `true`) | Controls error mode. `true` → plain `ValueError` (for v2 back-compat); `false` → typed `FFIECError` subclasses (`CredentialError`, `ValidationError`, etc.). Recommend setting to `false` in new code. |
 
 ## Output Compatibility
 
@@ -185,9 +231,21 @@ Exception hierarchy is unchanged:
 - `NoDataError` - no data for given parameters
 - `SOAPDeprecationError` - raised when SOAP classes are used (new in v3.0.0)
 
+## Behavioral changes AI agents should know (3.0.0rc4 — rc6)
+
+These are not migration steps but behavioral shifts that can bite code that "worked" in v2.x:
+
+1. **`date_output_format="python_format"` returns tz-aware datetimes (3.0.0rc6).** FFIEC publishes all timestamps in Washington, DC local wall-clock time; the library now attaches `zoneinfo.ZoneInfo("America/New_York")` in this mode. DST is honored. Affects `collect_reporting_periods`, `collect_ubpr_reporting_periods`, `collect_filers_submission_date_time`, and `collect_data`'s `quarter` column. If refactored code compares these datetimes with naive `datetime` values, it will raise `TypeError: can't compare offset-naive and offset-aware datetimes`. Attach a tz to the naive value, or call `.replace(tzinfo=None)` on the library's output.
+
+2. **`date_output_format` is now honored on list-returning methods (3.0.0rc6).** In v2.x, passing `date_output_format="python_format"` or `"string_yyyymmdd"` on `collect_reporting_periods`, `collect_ubpr_reporting_periods`, or `collect_filers_submission_date_time` was a silent no-op — the parameter was validated but ignored. If refactored code had a `datetime.strptime(...)` workaround to parse the returned strings, delete the workaround and trust the parameter.
+
+3. **`except ConnectionError:` may miss more errors (3.0.0rc6).** The REST code path no longer wraps `AttributeError` / `KeyError` / `TypeError` / `FFIECError` subclasses as `ConnectionError`. Code that relied on the wrap (e.g. to suppress transient API quirks surfacing as `AttributeError`) needs explicit handlers for those types.
+
+4. **Legacy-mode error messages got shorter (3.0.0rc6).** In the default legacy error mode, a polars-missing error used to arrive as `ValueError("Failed to retrieve ... via REST API: Polars not available")`. Now it's the clean `ValueError("Polars not available")`. Code grepping on the old "via REST API" prefix will need updating.
+
 ## Testing After Migration
 
 1. Replace `WebserviceCredentials` with `OAuth2Credentials` in test fixtures
 2. Replace `FFIECConnection()` with `None` as session parameter
 3. Use `Mock(spec=WebserviceCredentials)` if tests need a credential-like object for isinstance checks
-4. All output assertions should pass unchanged (format is identical)
+4. All output assertions should pass unchanged (format is identical) — **except** for `date_output_format="python_format"` assertions if the test previously expected a naive `datetime` (now tz-aware — see behavioral note 1 above).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ffiec-data-connect"
-version = "3.0.0rc6"
+version = "3.0.0"
 authors = [
     {name = "Civic Forge Solutions LLC", email = "michael@civicforge.solutions"},
 ]

--- a/src/ffiec_data_connect/__init__.py
+++ b/src/ffiec_data_connect/__init__.py
@@ -12,7 +12,7 @@ shut down on February 28, 2026.
 """
 
 # Version
-__version__ = "3.0.0rc6"
+__version__ = "3.0.0"
 
 # New async-compatible client
 from ffiec_data_connect.async_compatible import AsyncCompatibleClient, RateLimiter


### PR DESCRIPTION
## Scope

Cuts 3.0.0 stable from the rc6 code already on `main`. **No behavior changes** — this PR is purely the release marker work:

| File | Change |
|---|---|
| `pyproject.toml` | `version = "3.0.0rc6"` → `"3.0.0"` |
| `src/ffiec_data_connect/__init__.py` | `__version__ = "3.0.0rc6"` → `"3.0.0"` |
| `CHANGELOG.md` | New `[3.0.0] - 2026-04-22` entry at top; summarizes headline changes vs `2.0.5`. Preserves the full per-RC history below it. |
| `llms.txt` | Folded rc4–rc6 migration patterns and behavioral notes into the AI-agent refactoring guide. |

`pip install ffiec-data-connect` (no `--pre` flag) will pull 3.0.0 once this merges, is tagged, and is published.

## Why a separate PR instead of straight-to-main

The release artifacts move through the same review path as code changes (branch protection requires review). This is intentional — a version bump is as consequential as a code change for anyone tracking the library via lockfiles.

## What shipped in rc6 (reference)

3.0.0 carries the same code as rc6. Headline changes vs `2.0.5`:

- **SOAP removed.** `WebserviceCredentials`, `FFIECConnection`, `SOAPAdapter` → `SOAPDeprecationError` on instantiation.
- **Simplified calling convention**: `collect_*(creds, ...)`. The v2 `session=None, creds=creds` kwarg form still works with `DeprecationWarning`.
- **Python 3.11+ floor**, pandas 3.0+ baseline.
- **`output_type="xbrl"` / `"pdf"`** for raw-bytes passthrough.
- **Tz-aware `date_output_format="python_format"`** — datetime outputs carry `ZoneInfo("America/New_York")`.
- **Silent v2 no-ops promoted to errors** (`output_type="bytes"`, `output_type="polars"` without the extra, `date_output_format` stubs on list-returning methods).
- **Async support** via `AsyncCompatibleClient` + `RateLimiter`.
- **Typed exception hierarchy** (`FFIECError` base) — opt in with `disable_legacy_mode()` or `FFIEC_USE_LEGACY_ERRORS=false`.

The legacy-error-mode double-wrap fix from rc6 (clean `"Polars not available"` instead of misleading `"Failed to retrieve … via REST API: Polars not available"`) also ships here.

## Test plan

- [x] **806 unit tests pass** — same count as rc6 (no test changes in this PR)
- [x] **99.82% statement + branch coverage** (unchanged vs rc6)
- [x] CI toolchain clean locally: `black --check`, `isort --check`, `flake8`, `mypy`
- [x] PyPI classifier is already `Development Status :: 5 - Production/Stable` (shipped with rc6)
- [ ] CI to pass on this PR

## Post-merge sequence (not part of this PR)

1. Tag `v3.0.0` at the merge commit, push tag.
2. `python -m build` + `twine check dist/*` + `twine upload dist/*`.
3. `gh release create v3.0.0` **without** `--prerelease` (first stable release on 3.x).
4. Push the companion `call.report` commits so the documentation site picks up the version-string changes + the new `llms.txt` manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)